### PR TITLE
Fix Header on Static Drawer Disabled

### DIFF
--- a/CSS/css-scyfin/disable-static-drawer-backdrop.css
+++ b/CSS/css-scyfin/disable-static-drawer-backdrop.css
@@ -77,25 +77,34 @@
     position: absolute;
     top: 39px;
     left: 10px;
-    width: 270px;
+    width: 245px;
     height: 45px;
     background-color: rgba(35, 35, 35, 0.5) !important;
     border-radius: 50px !important;
     backdrop-filter: blur(50px) !important;
 }
+
+/* Reduce the size of the header when the logo is not present */
+.layout-desktop .skinHeader.semiTransparent .headerTop .headerLeft::before {
+    width: 160px;
+}
+
 .layout-desktop .headerLeft {
     padding: 2px !important;
     top: -3px !important;
 }
+
 .layout-desktop .pageTitle {
     z-index: 1099 !important;
 }
+
 @media (width: 1600px) {
     .layout-desktop:not(.transparentDocument) .headerLeft::before {
         top: 35px;
         left: 10px;
     }
 }
+
 @media (max-width: 1599px) {
     .layout-desktop:not(.transparentDocument) .headerLeft::before {
         top: 35px;

--- a/CSS/css-scyfin/disable-static-drawer.css
+++ b/CSS/css-scyfin/disable-static-drawer.css
@@ -71,25 +71,34 @@
     position: absolute;
     top: 39px;
     left: 10px;
-    width: 270px;
+    width: 245px;
     height: 45px;
     background-color: rgba(35, 35, 35, 0.5) !important;
     border-radius: 50px !important;
     backdrop-filter: blur(50px) !important;
 }
+
+/* Reduce the size of the header when the logo is not present */
+.layout-desktop .skinHeader.semiTransparent .headerTop .headerLeft::before {
+    width: 160px;
+}
+
 .layout-desktop .headerLeft {
     padding: 2px !important;
     top: -3px !important;
 }
+
 .layout-desktop .pageTitle {
     z-index: 1099 !important;
 }
+
 @media (width: 1600px) {
     .layout-desktop:not(.transparentDocument) .headerLeft::before {
         top: 35px;
         left: 10px;
     }
 }
+
 @media (max-width: 1599px) {
     .layout-desktop:not(.transparentDocument) .headerLeft::before {
         top: 35px;

--- a/CSS/css-scyfin/scyfin-theme-backdrop.css
+++ b/CSS/css-scyfin/scyfin-theme-backdrop.css
@@ -1,11 +1,10 @@
 /* Increase size of Jellyfin logo */
 .layout-desktop .pageTitleWithLogo {
     margin-left: 15px !important;
+    width: 100px !important;
     height: 40px !important;
     margin-top: 5px !important;
 }
-
-
 
 /* Static left drawer */
 .layout-desktop .mainDrawer {

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -1,11 +1,10 @@
 /* Increase size of Jellyfin logo */
 .layout-desktop .pageTitleWithLogo {
     margin-left: 15px !important;
+    width: 100px !important;
     height: 40px !important;
     margin-top: 5px !important;
 }
-
-
 
 /* Static left drawer */
 .layout-desktop .mainDrawer {

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -13,8 +13,6 @@
     width: 250px !important;
     /* Modified background color */
     background-color: #181818 !important;
-    /* Added border to right side */
-    border-right: 1px solid #3B3B3B !important;
     /* Move drawer behind header */
     z-index: 998 !important;
 }

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -146,15 +146,11 @@
     color: rgb(33, 149, 243) !important;
 }
 
-
-
 /* Modified background color */
-.backgroundContainer,
 .dialog,
 html {
     background-color: #0F0F0F !important;
 }
-
 
 
 /* Transparent header bar */


### PR DESCRIPTION
This fixes the issue where if browsing to a different route other than the homepage, then the drawer would remain the width of the logo even though Jellyfin removes the logo on pages which aren't the homepage.

### Before
![Before](https://github.com/loof2736/scyfin/assets/1347620/38047ee6-c9d3-4dac-9687-969cc03c4ea5)
### After
![After](https://github.com/loof2736/scyfin/assets/1347620/22450b74-12f3-41c4-b5eb-541760fe5236)

This also includes some more static mapping of the logos size, to fix minor div content leaking. 