### PR TITLE
Minor Style Refactoring

### DIFF
--- a/CSS/css-scyfin/scyfin-theme-backdrop.css
+++ b/CSS/css-scyfin/scyfin-theme-backdrop.css
@@ -64,7 +64,21 @@
     margin-right: -2% !important;
 }
 
+/* Hide 'My Media' title on Homepage */
+#indexPage .section0 .sectionTitle {
+    display: none;
+}
 
+/* Centralise the 'My Media (small)'  */
+#indexPage .section0 .itemsContainer.padded-left.padded-right {
+    justify-content: center;
+    padding-top: 15px;
+}
+
+#indexPage .section0 .itemsContainer.padded-left.padded-right .emby-button {
+    background: rgba(35, 35, 35, 0.5);
+    backdrop-filter: blur(50px);
+}
 
 /* Rounded cards */
 .cardContent,

--- a/CSS/css-scyfin/scyfin-theme-backdrop.css
+++ b/CSS/css-scyfin/scyfin-theme-backdrop.css
@@ -99,14 +99,17 @@
     background-color: black !important;
 }
 
-
-
 /* Green watched indicator */
 .playedIndicator {
-    background: #409843 !important;
+    /* background: rgb(64, 152, 67, 0.5) !important; */
+    background: linear-gradient(to bottom right, rgba(74, 150, 76, 0.5), rgba(32, 139, 35, 0.5)) !important;
 }
 
-
+.countIndicator, .fullSyncIndicator, .mediaSourceIndicator, .playedIndicator {
+    /* background: rgba(35, 35, 35, 0.5); */
+    background: linear-gradient(to bottom right, rgba(170, 92, 195, 0.5), rgba(0, 164, 220, 0.5));
+    backdrop-filter: blur(50px);
+}
 
 /* Rounded left drawer buttons */
 .navMenuOption,

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -610,9 +610,9 @@ html {
 
 /* Login page */
 .layout-desktop #loginPage {
-    display: flex !important;
-    justify-content: center !important;
-    align-items: center !important;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 .layout-desktop #loginPage .padded-left.padded-right.padded-bottom-page.margin-auto-y {
     background: #181818 !important;

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -99,14 +99,15 @@
     background-color: black !important;
 }
 
-
-
 /* Green watched indicator */
 .playedIndicator {
-    background: #409843 !important;
+    background: linear-gradient(to bottom right, rgba(74, 150, 76, 0.5), rgba(32, 139, 35, 0.5)) !important;
 }
 
-
+.countIndicator, .fullSyncIndicator, .mediaSourceIndicator, .playedIndicator {
+    background: linear-gradient(to bottom right, rgba(170, 92, 195, 0.5), rgba(0, 164, 220, 0.5));
+    backdrop-filter: blur(50px);
+}
 
 /* Rounded left drawer buttons */
 .navMenuOption,

--- a/CSS/css-scyfin/scyfin-theme.css
+++ b/CSS/css-scyfin/scyfin-theme.css
@@ -64,7 +64,21 @@
     margin-right: -2% !important;
 }
 
+/* Hide 'My Media' title on Homepage */
+#indexPage .section0 .sectionTitle {
+    display: none;
+}
 
+/* Centralise the 'My Media (small)'  */
+#indexPage .section0 .itemsContainer.padded-left.padded-right {
+    justify-content: center;
+    padding-top: 15px;
+}
+
+#indexPage .section0 .itemsContainer.padded-left.padded-right .emby-button {
+    background: rgba(35, 35, 35, 0.5);
+    backdrop-filter: blur(50px);
+}
 
 /* Rounded cards */
 .cardContent,


### PR DESCRIPTION
Changed the indicators slightly to reflect the style of the theme.
![image](https://github.com/loof2736/scyfin/assets/1347620/c9840e95-7e95-48ca-8254-d44c7db808b7)

Removed the "My Media" title as it's obvious what the section is.
![image](https://github.com/loof2736/scyfin/assets/1347620/c2bbefbc-1d02-4feb-ab35-9d65510d9f93)

When users use "My Media (small)" it will centralise the pills to be in-line with the navigation menu. 
![image](https://github.com/loof2736/scyfin/assets/1347620/5034905c-0e3d-4eeb-b764-e5fba9fd06c5)
