### PR TITLE
Add background blur for Logo / Menu Drawer icon on mobile view

### DIFF
--- a/CSS/scyfin-theme.css
+++ b/CSS/scyfin-theme.css
@@ -315,6 +315,24 @@ html,
     top: -17px !important;
 }
 /* Mobile fixes */
+.layout-mobile .headerTop {
+    justify-content: space-between !important;
+}
+
+.layout-mobile .headerLeft {
+    height: 45px !important;
+    background-color: var(--primary-background-transparent) !important;
+    border-radius: 50px !important;
+    backdrop-filter: blur(var(--blur)) !important;
+    flex-grow: unset !important;
+    -webkit-flex-grow: unset !important;
+}
+
+.layout-mobile .pageTitleWithDefaultLogo {
+    width: unset !important;
+    aspect-ratio: 4 / 1 !important;
+}
+
 .layout-mobile .sectionTabs {
     margin-left: auto !important;
     margin-right: auto !important;


### PR DESCRIPTION
I was always annoyed by the menu drawer & logo not having the same blurred background as the header buttons and section tabs.

This adds CSS overrides for the .layout-mobile view to add the same rounded background with a blur filter that `.headerRight` uses. Instead of adding `.headerLeft` to the declarations for those styles, I created a separate override under `Mobile fixes` so that the `background-blur` declaration of .headerRight won't need to be unset for the desktop view.

I've uploaded the exact rules I'm using on my Jellyfin instance to override the default / scyfin rules on https://github.com/alvitali/scyfin/commit/240ad6538bcd64619db748fd3ecd02275abc01f1 where the changes are explained in detail with comments.

Setting the width of `.pageTitleWithDefaultLogo` with the `aspect-ratio` declaration is rather fragile and could definitely be improved. However I didn't find a more robust way to set the width as jellyfin-web uses `background-image` to set the logo instead of an <img> tag. As long as the logo stays the same, this should work fine though. Heads up as I eyeballed the aspect-ratio for logo which does not correspond to the precise measurements of the default logo but I wanted to get this up here for another pair of eyes