### PR TITLE
Create big-picture.css

### DIFF
--- a/CSS/big-picture.css
+++ b/CSS/big-picture.css
@@ -1,0 +1,48 @@
+.backgroundContainer.withBackdrop {
+    background-color: transparent !important;
+    background-image:
+        linear-gradient(90deg,rgba(0, 0, 0, 1) 13vw, rgba(0, 0, 0, 0.8) 17vw, rgba(0, 0, 0, 0) 30vw),
+        linear-gradient(0deg,rgba(0, 0, 0, 1) 5vh, rgba(0, 0, 0, 0) 46vh);
+    mask:
+        linear-gradient(90deg,rgba(0, 0, 0, 1) 33vw, rgba(0, 0, 0, 0) 44vw),
+        linear-gradient(180deg,rgba(0, 0, 0, 0) calc(100vw * 0.29), rgba(0, 0, 0, 1) calc(100vw * 0.39));
+    backdrop-filter: blur(300px);
+}
+
+.backdropImage {
+    background-position: top right;
+    background-size: 70vw;
+    background-repeat: repeat;
+}
+
+.noBackdropTransparency .detailPagePrimaryContainer {
+    background-color: transparent !important;
+    background: linear-gradient(180deg,rgba(0, 0, 0, 0) 0px, rgba(0, 0, 0, 0.75) 100px);
+}
+
+.layout-desktop .detailSectionContent, .trackSelections, .layout-desktop .detailsGroupItem {
+    background: rgba(0, 0, 0, 0.3) !important;
+}
+
+#itemDetailPage .padded-bottom-page {
+    background-color: rgba(0, 0, 0, 0.75) !important;
+}
+
+.nameContainer {
+    color: white;
+    text-shadow: black 0 0 4px;
+}
+
+.detailTrackSelect:enabled {
+    background-color: rgba(122, 122, 122, 0.2) !important;
+    border: 0;
+    backdrop-filter: blur(var(--blur)) !important;
+}
+
+.listItem:hover {
+    background: rgba(0, 0, 0, 0.3) !important;
+}
+
+.detailLogo {
+    height: 25vh !important;
+}


### PR DESCRIPTION
I propose an alternative "big picture" backdrop view for currently selected media. Below is a comparison.

<img width="1878" height="956" alt="enhancedtheme-before" src="https://github.com/user-attachments/assets/07c9768f-fc4c-4ef6-a984-b3fda3e0c04b" />
<img width="1878" height="956" alt="enhancedtheme-after" src="https://github.com/user-attachments/assets/aecba39a-4dc4-4cad-a83f-d624346a9945" />

Partially inspired by Arctic Horizon 2 (jurialmonkey's Kodi theme)'s approach, I wanted to find a good middle ground between the confined appearance of the default backdrop, and the broadly symmetrical appearance of the transparent view. What I've done was shrink the image into the top right corner, have the image infinitely repeat, and heavily blurred these surrounding repetitions to get a rough approximation of the backdrop's color. The interface is transparent but not overly clear, showing enough of both the backdrop and the interface's legible contents.

You can try this yourself by pasting this below the base Scyfin theme import. I'm admittedly a bit of a novice at CSS, so this approach could be horribly unoptimized for all I know.

`@import url('https://cdn.jsdelivr.net/gh/MuffinOfPotato/scyfin/CSS/big-picture.css');`

This is untested on non-Chromium browsers.