### PR TITLE
Removed absolute positioning from .btnForgotPassword

### DIFF
--- a/CSS/scyfin-theme.css
+++ b/CSS/scyfin-theme.css
@@ -1008,7 +1008,6 @@ html,
     background: none !important;
     font-weight: normal !important;
     width: 150px !important;
-    position: absolute !important;
     margin-left: 320px !important;
     top: -200px !important;
     font-size: smaller !important;


### PR DESCRIPTION
Before:
<img width="626" height="613" alt="image" src="https://github.com/user-attachments/assets/593b6f55-10c1-47fe-aad7-d4ff42c32d31" />

After:
<img width="658" height="655" alt="image" src="https://github.com/user-attachments/assets/9ba19053-e535-4c3b-babd-0d9d7acb31a8" />
